### PR TITLE
Fixed previous pull request

### DIFF
--- a/src/Ixudra/Curl/Builder.php
+++ b/src/Ixudra/Curl/Builder.php
@@ -6,15 +6,15 @@ class Builder {
     protected $curlObject = null;
 
     protected $curlOptions = array(
-        'RETURN_TRANSFER'       => true,
-        'FAIL_ON_ERROR'         => true,
-        'FOLLOW_LOCATION'       => false,
-        'CONNECT_TIMEOUT'       => '',
+        'RETURNTRANSFER'        => true,
+        'FAILONERROR'           => true,
+        'FOLLOWLOCATION'        => false,
+        'CONNECTTIMEOUT'        => '',
         'TIMEOUT'               => 30,
-        'USER_AGENT'            => '',
+        'USERAGENT'             => '',
         'URL'                   => '',
         'POST'                  => false,
-        'HTTP_HEADER'           => array(),
+        'HTTPHEADER'            => array(),
     );
 
     protected $packageOptions = array(


### PR DESCRIPTION
The `protected $curlOptions` keys where renamed. Changed them to the correct names documented on this page: http://php.net/manual/en/function.curl-setopt.php